### PR TITLE
Add link to St. Louis PWL.

### DIFF
--- a/source/chapters.yml
+++ b/source/chapters.yml
@@ -18,6 +18,7 @@
 - :name: stlouis
   :title: St. Louis
   :description: The St. Louis chapter of Papers We Love
+  :url: http://www.meetup.com/Papers-We-Love-in-saint-louis/
 - :name: columbus
   :title: Columbus
   :description: The Columbus chapter of Papers We Love


### PR DESCRIPTION
This fixes the link on the top of the main page.