### PR TITLE
Moved the Dallas chapter off of Meetup.com

### DIFF
--- a/source/chapters.yml
+++ b/source/chapters.yml
@@ -77,7 +77,7 @@
 - name: dallas
   title: Dallas
   description: The Dallas chapter of Papers We Love
-  url: http://www.meetup.com/Papers-We-Love-Dallas/
+  url: http://www.papersdallas.com
   meetup_url: Papers-We-Love-Dallas
 - name: chicago
   title: Chicago


### PR DESCRIPTION
I moved the Dallas chapter to a static site. Meetup wasn't providing enough value for the price.