### PR TITLE
(Re)-add Washington, DC area chapter

### DIFF
--- a/source/chapters.yml
+++ b/source/chapters.yml
@@ -164,3 +164,8 @@
   description: The Portland chapter of Papers We Love
   url: "/chapter/portland"
   meetup_url: Papers-We-Love-pdx
+- name: washington-dc
+  title: Washington, DC
+  description: The Washington, DC/Northern Virginia chapter of Papers We Love
+  url: "/chapter/washington-dc"
+  meetup_url: Papers-We-Love-DC-NoVA

--- a/source/partials/chapters/_washington-dc.erb.markdown
+++ b/source/partials/chapters/_washington-dc.erb.markdown
@@ -1,0 +1,22 @@
+# Washington, DC
+
+The Washington, DC/Northern Virginia chapter of Papers We Love
+
+Papers We Love has a **[Code of Conduct](https://github.com/papers-we-love/papers-we-love/blob/master/CODE_OF_CONDUCT.md)**. Please contact one of the Meetup's organizers if anyone is not following it. Be good to each other and to the PWL community!
+
+## Chapter details
+
+**Sign-up:** Please RSVP for meetings via [Meetup.com][meetup]
+
+**Twitter:** [@paperswelovedc][twitter]
+
+**Slack:** [#paperswelove][slack-channel] on DCTech Slack (get an invite [here][slack-invite])
+
+**Organizers:** [Lee Sharma][lee] and [Howard Miller][howard]
+
+[meetup]: http://www.meetup.com/Papers-We-Love-DC-NoVA
+[twitter]: https://twitter.com/paperswelovedc
+[slack-channel]: https://dctech.slack.com/messages/paperswelove/
+[slack-invite]: http://www.dctechslack.com/
+[lee]: https://twitter.com/theleesharma
+[howard]: https://twitter.com/hmmiller


### PR DESCRIPTION
We're restarting the DC-area Papers We Love group; our first meetup will be on August 24th. You can find our Meetup group [here](http://www.meetup.com/Papers-We-Love-DC-NoVA/).