### PR TITLE
Lebanon chapter

### DIFF
--- a/source/chapters.yml
+++ b/source/chapters.yml
@@ -179,3 +179,7 @@
   description: The Winnipeg chapter of Papers We Love
   url: http://pwlwpg.ca
   meetup_url: Papers-We-Love-Winnipeg
+- name: lebanon
+  title: Lebanon
+  description: The Lebanon chapter of Papers We Love
+  url: http://www.paperswelovelb.club

--- a/source/partials/chapters/_lebanon.erb.markdown
+++ b/source/partials/chapters/_lebanon.erb.markdown
@@ -1,0 +1,19 @@
+# Lebanon Chapter
+
+If you are living, studying, or working in Lebanon and you like computer science, then you might enjoy reading and discussing papers in our group.
+
+We will be holding regular meetups in Lebanon and we hope you can join us!
+
+Papers We Love has a **[Code of Conduct](https://github.com/papers-we-love/papers-we-love/blob/master/CODE_OF_CONDUCT.md)**. Please contact one of the chapter organizers if anyone is not following it. Be good to each other and to the PWL community!
+
+## Chapter details
+
+**Sign-up:** Please RSVP for meetings via [Facebook](http://www.paperswelovelb.club)
+
+**Twitter:** [@paperswelovelb](https://twitter.com/paperswelovelb)
+
+**Organizers:**
+
+- [Saeid Al-Wazzan](https://twitter.com/saeidw)
+- [Christophe Zoghbi](https://twitter.com/kristoffzoghbi)
+


### PR DESCRIPTION
This adds details for the Lebanon chapter to the chapters.yml file, as well as a template for the Lebanon chapter.

I omitted the `meetup_url` key in the YAML file since we do not currently use Meetup.

The Lebanon chapter discussion is in papers-we-love/papers-we-love#444