### PR TITLE
Hide old banner

### DIFF
--- a/source/stylesheets/_banner.scss
+++ b/source/stylesheets/_banner.scss
@@ -18,6 +18,7 @@ $paleTertiary: desaturate(#FEE6D2, 20);
   background: url("/images/paper.svg") no-repeat;
   background-size: auto 300px;
   background-position: 120% 80%;
+  display: none;
 
   @media (max-width: 768px) {
     background: none;


### PR DESCRIPTION
The current version of site displays the banner for a past event on Sept 28th. Thus, till another banner is added, the banner should be hidden.