### PR TITLE
Ben lindsay sandy vanderbleek

### DIFF
--- a/source/2018-05-14-ben-lindsay-on-hyper-log-log.html.markdown
+++ b/source/2018-05-14-ben-lindsay-on-hyper-log-log.html.markdown
@@ -24,7 +24,7 @@ READMORE
 * **Meetup:** [https://www.meetup.com/papers-we-love/events/245860299/](https://bit.ly/2sPHrDU)
 * **Paper:** [](https://bit.ly/1QlcaxD)
 * **Slides:** []()
-* **Audio:** []()
+* **Audio:** [https://www.mixcloud.com/paperswelove/ben-lindsay-on-hyperloglog/](https://bit.ly/2t5EwqL)
 
 **Description**
 
@@ -36,7 +36,8 @@ This extended abstract describes and analyses a near-optimal probabilistic algor
 Ben Linsay (http://blinsay.com/) (@blinsay (https://twitter.com/blinsay)) is somehow still a software engineer. He's worked on distributed data processing pipelines in adtech, built and maintained APIs for small startups, and has accidentally been a DBA twice. Ben has written a couple HyperLogLog implementations in his spare time and doesn't really want to show them to anyone.
 
 **Audio**
-<iframe width="100%" height="60" src="" frameborder="0" ></iframe>
+
+<iframe width="100%" height="60" src="https://www.mixcloud.com/widget/iframe/?hide_cover=1&mini=1&feed=%2Fpaperswelove%2Fben-lindsay-on-hyperloglog%2F" frameborder="0" ></iframe>
 
 **Slides**
 

--- a/source/2018-05-14-ben-lindsay-on-hyper-log-log.html.markdown
+++ b/source/2018-05-14-ben-lindsay-on-hyper-log-log.html.markdown
@@ -1,0 +1,51 @@
+---
+title: "Ben Lindsay on HyperLogLog"
+date: 2018-06-13
+author: Andrew Gross
+category: video
+tags: meetup, video
+label: Video
+description: "Ben Lindsay on HyperLogLog"
+ogp:
+  og:
+    description: "Ben Lindsay on HyperLogLog"
+  fb:
+    description: "Ben Lindsay on HyperLogLog"
+---
+
+<iframe class="video" width="560" height="315" src="https://www.youtube.com/embed/y3fTaxA8PkU" frameborder="0" allowfullscreen></iframe>
+
+READMORE
+
+## New York - May 14th, 2018
+
+****
+
+* **Meetup:** [https://www.meetup.com/papers-we-love/events/245860299/](https://bit.ly/2sPHrDU)
+* **Paper:** [](https://bit.ly/1QlcaxD)
+* **Slides:** []()
+* **Audio:** []()
+
+**Description**
+
+This extended abstract describes and analyses a near-optimal probabilistic algorithm, HyperLogLog, dedicated to estimating the number of distinct elements (the cardinality) of very large data ensembles. Using an auxiliary memory of m units (typically, "short bytes"), HyperLogLog performs a single pass over the data and produces an estimate of the cardinality such that the relative accuracy (the standard error) is typically about 1.04/√m. This improves on the best previously known cardinality estimator, LogLog, whose accuracy can be matched by consuming only 64% of the original memory. For instance, the new algorithm makes it possible to estimate cardinalities well beyond 10^9 with a typical accuracy of 2% while using a memory of only 1.5 kilobytes. The algorithm parallelizes optimally and adapts to the sliding window model.
+
+
+**Bio**
+
+Ben Linsay (http://blinsay.com/) (@blinsay (https://twitter.com/blinsay)) is somehow still a software engineer. He's worked on distributed data processing pipelines in adtech, built and maintained APIs for small startups, and has accidentally been a DBA twice. Ben has written a couple HyperLogLog implementations in his spare time and doesn't really want to show them to anyone.
+
+**Audio**
+<iframe width="100%" height="60" src="" frameborder="0" ></iframe>
+
+**Slides**
+
+<iframe class="video" allowfullscreen="true" allowtransparency="true" frameborder="0" height="596" mozallowfullscreen="true" src="//speakerdeck.com/player/" style="border:0; padding:0; margin:0; background:transparent;" webkitallowfullscreen="true" width="710"></iframe>
+
+---
+
+<p style="display: flex; flex-direction: row; justify-content: center; align-items: center;">
+  <a href="https://www.twosigma.com/"><img src="/images/TwoSigma_RGB.jpg" alt="TwoSigma" title="TwoSigma - Platinum Sponsor of Papers We Love NYC" style="width: 200px; margin: 0 1em 0 0;"></a> <span style="flex: 1;">The <strong>New York Chapter</strong> would like to thank <a href="https://www.twosigma.com">TwoSigma</a> for helping to make this meetup possible.</span>
+</p>
+
+---

--- a/source/2018-05-14-ben-lindsay-on-hyper-log-log.html.markdown
+++ b/source/2018-05-14-ben-lindsay-on-hyper-log-log.html.markdown
@@ -1,5 +1,5 @@
 ---
-title: "Ben Lindsay on HyperLogLog"
+title: "Ben Linsay on HyperLogLog"
 date: 2018-06-13
 author: Andrew Gross
 category: video

--- a/source/2018-05-14-ben-lindsay-on-hyper-log-log.html.markdown
+++ b/source/2018-05-14-ben-lindsay-on-hyper-log-log.html.markdown
@@ -22,8 +22,8 @@ READMORE
 ****
 
 * **Meetup:** [https://www.meetup.com/papers-we-love/events/245860299/](https://bit.ly/2sPHrDU)
-* **Paper:** [](https://bit.ly/1QlcaxD)
-* **Slides:** []()
+* **Paper:** [http://algo.inria.fr/flajolet/Publications/FlFuGaMe07.pdf](https://bit.ly/1QlcaxD)
+* **Slides:** [https://speakerdeck.com/pwl/ben-linsay-on-hyperloglog](https://bit.ly/2JMeza6)
 * **Audio:** [https://www.mixcloud.com/paperswelove/ben-lindsay-on-hyperloglog/](https://bit.ly/2t5EwqL)
 
 **Description**
@@ -41,7 +41,8 @@ Ben Linsay (http://blinsay.com/) (@blinsay (https://twitter.com/blinsay)) is som
 
 **Slides**
 
-<iframe class="video" allowfullscreen="true" allowtransparency="true" frameborder="0" height="596" mozallowfullscreen="true" src="//speakerdeck.com/player/" style="border:0; padding:0; margin:0; background:transparent;" webkitallowfullscreen="true" width="710"></iframe>
+<script async class="speakerdeck-embed" data-id="03844f8896fa43eab764b79f90dcab2b" data-ratio="1.77777777777778" src="//speakerdeck.com/assets/embed.js"></script>
+
 
 ---
 

--- a/source/2018-05-14-sandy-vanderbleek-a-widespread-error-in-unification-algorithms.html.markdown
+++ b/source/2018-05-14-sandy-vanderbleek-a-widespread-error-in-unification-algorithms.html.markdown
@@ -24,7 +24,7 @@ READMORE
 * **Meetup:** [https://www.meetup.com/papers-we-love/events/245860299/](https://bit.ly/2sPHrDU)
 * **Paper:** [https://norvig.com/unify-bug.pdf](https://bit.ly/2y9jUCS)
 * **Slides:** []()
-* **Audio:** []()
+* **Audio:** [https://www.mixcloud.com/paperswelove/sandy-vanderbleek-on-peter-norvigs-correcting-a-widespread-error-in-unification-algorithms/](https://bit.ly/2lj6gUM)
 
 **Description**
 
@@ -35,7 +35,8 @@ Peter Norvig found an error in the unification algorithm presented in his AI tex
 Sandy Vanderbleek (https://twitter.com/haskellandchill) has been a software engineer in industry and academia for 10 years. He is currently a Data Scientist at Publicis Media (http://www.publicisgroupe.com/en/services/services-publicis-media-en). His research interests are formal methods and computational logic with applications to industry.
 
 **Audio**
-<iframe width="100%" height="60" src="" frameborder="0" ></iframe>
+
+<iframe width="100%" height="60" src="https://www.mixcloud.com/widget/iframe/?hide_cover=1&mini=1&feed=%2Fpaperswelove%2Fsandy-vanderbleek-on-peter-norvigs-correcting-a-widespread-error-in-unification-algorithms%2F" frameborder="0" ></iframe>
 
 **Slides**
 

--- a/source/2018-05-14-sandy-vanderbleek-a-widespread-error-in-unification-algorithms.html.markdown
+++ b/source/2018-05-14-sandy-vanderbleek-a-widespread-error-in-unification-algorithms.html.markdown
@@ -23,7 +23,7 @@ READMORE
 
 * **Meetup:** [https://www.meetup.com/papers-we-love/events/245860299/](https://bit.ly/2sPHrDU)
 * **Paper:** [https://norvig.com/unify-bug.pdf](https://bit.ly/2y9jUCS)
-* **Slides:** []()
+* **Slides:** [http://slides.com/sandyvanderbleek/correcting#/](https://bit.ly/2MGIMW6)
 * **Audio:** [https://www.mixcloud.com/paperswelove/sandy-vanderbleek-on-peter-norvigs-correcting-a-widespread-error-in-unification-algorithms/](https://bit.ly/2lj6gUM)
 
 **Description**
@@ -40,7 +40,7 @@ Sandy Vanderbleek (https://twitter.com/haskellandchill) has been a software engi
 
 **Slides**
 
-<iframe class="video" allowfullscreen="true" allowtransparency="true" frameborder="0" height="596" mozallowfullscreen="true" src="//speakerdeck.com/player/" style="border:0; padding:0; margin:0; background:transparent;" webkitallowfullscreen="true" width="710"></iframe>
+<iframe src="//slides.com/sandyvanderbleek/correcting/embed" width="576" height="420" scrolling="no" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 
 ---
 

--- a/source/2018-05-14-sandy-vanderbleek-a-widespread-error-in-unification-algorithms.html.markdown
+++ b/source/2018-05-14-sandy-vanderbleek-a-widespread-error-in-unification-algorithms.html.markdown
@@ -1,0 +1,50 @@
+---
+title: "Sandy Vanderbleek on Peter Norvig's Correcting A Widespread Error in Unification Algorithms"
+date: 2018-06-13
+author: Andrew Gross
+category: video
+tags: meetup, video
+label: Video
+description: "Sandy Vanderbleek on Peter Norvig's Correcting A Widespread Error in Unification Algorithms"
+ogp:
+  og:
+    description: "Sandy Vanderbleek on Peter Norvig's Correcting A Widespread Error in Unification Algorithms"
+  fb:
+    description: "Sandy Vanderbleek on Peter Norvig's Correcting A Widespread Error in Unification Algorithms"
+---
+
+<iframe class="video" width="560" height="315" src="https://www.youtube.com/embed/dBqYdVjqSBc" frameborder="0" allowfullscreen></iframe>
+
+READMORE
+
+## New York - May 14th, 2018
+
+****
+
+* **Meetup:** [https://www.meetup.com/papers-we-love/events/245860299/](https://bit.ly/2sPHrDU)
+* **Paper:** [https://norvig.com/unify-bug.pdf](https://bit.ly/2y9jUCS)
+* **Slides:** []()
+* **Audio:** []()
+
+**Description**
+
+Peter Norvig found an error in the unification algorithm presented in his AI textbooks and several others and wrote a brief paper about it. While his paper focuses on Lisp implementations of higher-order unification, I will restrict the problem to syntactic propositional unification and present the erroneous and correct algorithm in a pattern and substitution notation.
+
+**Bio**
+
+Sandy Vanderbleek (https://twitter.com/haskellandchill) has been a software engineer in industry and academia for 10 years. He is currently a Data Scientist at Publicis Media (http://www.publicisgroupe.com/en/services/services-publicis-media-en). His research interests are formal methods and computational logic with applications to industry.
+
+**Audio**
+<iframe width="100%" height="60" src="" frameborder="0" ></iframe>
+
+**Slides**
+
+<iframe class="video" allowfullscreen="true" allowtransparency="true" frameborder="0" height="596" mozallowfullscreen="true" src="//speakerdeck.com/player/" style="border:0; padding:0; margin:0; background:transparent;" webkitallowfullscreen="true" width="710"></iframe>
+
+---
+
+<p style="display: flex; flex-direction: row; justify-content: center; align-items: center;">
+  <a href="https://www.twosigma.com/"><img src="/images/TwoSigma_RGB.jpg" alt="TwoSigma" title="TwoSigma - Platinum Sponsor of Papers We Love NYC" style="width: 200px; margin: 0 1em 0 0;"></a> <span style="flex: 1;">The <strong>New York Chapter</strong> would like to thank <a href="https://www.twosigma.com">TwoSigma</a> for helping to make this meetup possible.</span>
+</p>
+
+---


### PR DESCRIPTION
Youtube Vides are ready to roll

1. Speakerdeck went through some big changes.  I created a new account to host this set of slides and cribbed from @DarrenN's previous PR for the embed for Ben Linsay's.

2. For Sandy's slides he gave me a link to slides.com.  It had no way to export the slides easily, so I used that URL for the bit.ly link, and used their custom embed block instead of our normal speakerdeck style.
